### PR TITLE
Move binary parser into dedicated BinaryParser class

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -11,6 +11,7 @@ set(SOURCE_FILES
     isobmf/IsoBmfTypes.h
     isobmf/IsoBmfInterfaces.h
     isobmf/IsoBmfUtils.h
+    isobmf/BinaryParser.h
     isobmf/BaseParserFactory.h
     isobmf/BaseParserFactory.cpp
     isobmf/BaseBoxParser.h

--- a/src/isobmf/BaseBoxParser.h
+++ b/src/isobmf/BaseBoxParser.h
@@ -3,9 +3,7 @@
 
 #include "IsoBmfInterfaces.h"
 
-#include <array>
 #include <iostream>
-#include <stdexcept>
 #include <string>
 
 namespace isobmf {
@@ -53,37 +51,6 @@ public:
             os << "  ";
         }
         return os;
-    }
-
-protected:
-    // Temporary parse buffer
-    std::array<std::uint8_t, 64> m_buf;
-    std::size_t m_pos = 0;
-
-    /**
-     * @brief Append character to buffer and return new buffer length
-     * @param ch Char to append
-     * @return Buffer length
-     */
-    std::size_t putChar(std::uint8_t ch)
-    {
-        if (m_pos >= m_buf.size()) {
-            throw std::out_of_range("Box parser buffer overflow");
-        }
-        m_buf[m_pos++] = ch;
-        return m_pos;
-    }
-
-    template <class T>
-    T getAs() const noexcept
-    {
-        T result = 0;
-        std::size_t shift = (sizeof(T) - 1) * 8;
-        for (std::size_t i = 0; i < sizeof(T); i++) {
-            result |= static_cast<T>(m_buf[i]) << shift;
-            shift -= 8;
-        }
-        return result;
     }
 
 private:

--- a/src/isobmf/BinaryParser.h
+++ b/src/isobmf/BinaryParser.h
@@ -1,0 +1,73 @@
+
+#pragma once
+
+#include <array>
+#include <cstdint>
+#include <stdexcept>
+
+namespace isobmf {
+
+template <std::size_t MaxSize>
+class BinaryParser
+{
+public:
+    std::size_t size() const noexcept
+    {
+        return m_pos;
+    }
+
+    std::size_t capacity() const noexcept
+    {
+        return m_buf.size();
+    }
+
+    bool empty() const noexcept
+    {
+        return size() == 0;
+    }
+
+    void reset() noexcept
+    {
+        m_pos = 0;
+    }
+
+    std::size_t putChar(std::uint8_t ch)
+    {
+        if (m_pos >= m_buf.size()) {
+            throw std::out_of_range("Binary parser overflow");
+        }
+        m_buf[m_pos++] = ch;
+        return m_pos;
+    }
+
+    template <class T>
+    T getAs() const
+    {
+        if (m_pos < sizeof(T)) {
+            throw std::out_of_range("Binary parser underflow");
+        }
+        T result = 0;
+        std::size_t shift = (sizeof(T) - 1) * 8;
+        for (std::size_t i = 0; i < sizeof(T); i++) {
+            result |= static_cast<T>(m_buf[i]) << shift;
+            shift -= 8;
+        }
+        return result;
+    }
+
+    const auto begin() const noexcept
+    {
+        return m_buf.begin();
+    }
+
+    const auto end() const noexcept
+    {
+        return m_buf.begin() + m_pos;
+    }
+
+private:
+    std::array<std::uint8_t, MaxSize> m_buf;
+    std::size_t m_pos = 0;
+};
+
+} // namespace

--- a/src/isobmf/ContainerBoxParser.h
+++ b/src/isobmf/ContainerBoxParser.h
@@ -2,6 +2,7 @@
 #pragma once
 
 #include "BaseBoxParser.h"
+#include "BinaryParser.h"
 
 #include <memory>
 
@@ -54,8 +55,8 @@ private:
 
     const ParserFactory& m_boxFactory;
 
+    BinaryParser<8> m_parser;
     State m_state = State::CompactSize;
-
     BoxSize m_childBoxSize;
     std::unique_ptr<BoxParser> m_childBoxParser;
     BoxSize m_dataLeft;

--- a/src/isobmf/FileTypeBoxParser.cpp
+++ b/src/isobmf/FileTypeBoxParser.cpp
@@ -8,24 +8,24 @@ void FileTypeBoxParser::parseChar(std::uint8_t ch)
 {
     switch (m_state) {
     case State::MajorBrand:
-        if (putChar(ch) == 4) {
-            m_majorBrand = getAs<std::uint32_t>();
+        if (m_parser.putChar(ch) == 4) {
+            m_majorBrand = m_parser.getAs<std::uint32_t>();
             m_state = State::MinorVersion;
-            m_pos = 0;
+            m_parser.reset();
         }
         break;
     case State::MinorVersion:
-        if (putChar(ch) == 4) {
-            m_minorVersion = getAs<std::uint32_t>();
+        if (m_parser.putChar(ch) == 4) {
+            m_minorVersion = m_parser.getAs<std::uint32_t>();
             m_state = State::CompatibleBrands;
-            m_pos = 0;
+            m_parser.reset();
         }
         break;
     case State::CompatibleBrands:
-        if (putChar(ch) == 4) {
-            const auto brandCode = getAs<std::uint32_t>();
+        if (m_parser.putChar(ch) == 4) {
+            const auto brandCode = m_parser.getAs<std::uint32_t>();
             m_compatibleBrands.push_back(brandCode);
-            m_pos = 0;
+            m_parser.reset();
         }
         break;
     }

--- a/src/isobmf/FileTypeBoxParser.h
+++ b/src/isobmf/FileTypeBoxParser.h
@@ -2,6 +2,7 @@
 #pragma once
 
 #include "FullBoxParser.h"
+#include "BinaryParser.h"
 
 #include <vector>
 
@@ -40,6 +41,7 @@ private:
         CompatibleBrands,
     };
 
+    BinaryParser<4> m_parser;
     State m_state = State::MajorBrand;
     std::uint32_t m_majorBrand = 0;
     std::uint32_t m_minorVersion = 0;

--- a/src/isobmf/MovieFragmentHeaderBoxParser.cpp
+++ b/src/isobmf/MovieFragmentHeaderBoxParser.cpp
@@ -7,16 +7,16 @@ void MovieFragmentHeaderBoxParser::parseChar(std::uint8_t ch)
 {
     switch (m_state) {
     case State::Reserved:
-        if (putChar(ch) == 4) {
+        if (m_parser.putChar(ch) == 4) {
             m_state = State::SequenceNumber;
-            m_pos = 0;
+            m_parser.reset();
         }
         break;
     case State::SequenceNumber:
-        if (putChar(ch) == 4) {
-            m_sequenceNumber = getAs<std::uint32_t>();
+        if (m_parser.putChar(ch) == 4) {
+            m_sequenceNumber = m_parser.getAs<std::uint32_t>();
             m_state = State::Done;
-            m_pos = 0;
+            m_parser.reset();
         }
         break;
     case State::Done:

--- a/src/isobmf/MovieFragmentHeaderBoxParser.h
+++ b/src/isobmf/MovieFragmentHeaderBoxParser.h
@@ -2,6 +2,7 @@
 #pragma once
 
 #include "FullBoxParser.h"
+#include "BinaryParser.h"
 
 namespace isobmf {
 
@@ -35,6 +36,7 @@ private:
         Done,
     };
 
+    BinaryParser<4> m_parser;
     State m_state = State::Reserved;
     std::uint32_t m_sequenceNumber = 0;
 };

--- a/src/isobmf/TrackFragmentHeaderBoxParser.cpp
+++ b/src/isobmf/TrackFragmentHeaderBoxParser.cpp
@@ -7,15 +7,15 @@ void TrackFragmentHeaderBoxParser::parseChar(std::uint8_t ch)
 {
     switch (m_state) {
     case State::TfFlags:
-        if (putChar(ch) == 4) {
-            m_tfFlags = getAs<std::uint32_t>();
+        if (m_parser.putChar(ch) == 4) {
+            m_tfFlags = m_parser.getAs<std::uint32_t>();
             m_state = State::TrackId;
-            m_pos = 0;
+            m_parser.reset();
         }
         break;
     case State::TrackId:
-        if (putChar(ch) == 4) {
-            m_trackId = getAs<std::uint32_t>();
+        if (m_parser.putChar(ch) == 4) {
+            m_trackId = m_parser.getAs<std::uint32_t>();
             if (m_tfFlags & TfFlag_BaseDataOffset) {
                 m_state = State::BaseDataOffset;
             } else if (m_tfFlags & TfFlag_SampleDescriptionIndex) {
@@ -29,12 +29,12 @@ void TrackFragmentHeaderBoxParser::parseChar(std::uint8_t ch)
             } else {
                 m_state = State::Done;
             }
-            m_pos = 0;
+            m_parser.reset();
         }
         break;
     case State::BaseDataOffset:
-        if (putChar(ch) == 8) {
-            m_baseDataOffset = getAs<std::uint64_t>();
+        if (m_parser.putChar(ch) == 8) {
+            m_baseDataOffset = m_parser.getAs<std::uint64_t>();
             if (m_tfFlags & TfFlag_SampleDescriptionIndex) {
                 m_state = State::SampleDescriptionIndex;
             } else if (m_tfFlags & TfFlag_DefaultSampleDuration) {
@@ -46,12 +46,12 @@ void TrackFragmentHeaderBoxParser::parseChar(std::uint8_t ch)
             } else {
                 m_state = State::Done;
             }
-            m_pos = 0;
+            m_parser.reset();
         }
         break;
     case State::SampleDescriptionIndex:
-        if (putChar(ch) == 4) {
-            m_sampleDescriptionIndex = getAs<std::uint32_t>();
+        if (m_parser.putChar(ch) == 4) {
+            m_sampleDescriptionIndex = m_parser.getAs<std::uint32_t>();
             if (m_tfFlags & TfFlag_DefaultSampleDuration) {
                 m_state = State::DefaultSampleDuration;
             } else if (m_tfFlags & TfFlag_DefaultSampleSize) {
@@ -61,12 +61,12 @@ void TrackFragmentHeaderBoxParser::parseChar(std::uint8_t ch)
             } else {
                 m_state = State::Done;
             }
-            m_pos = 0;
+            m_parser.reset();
         }
         break;
     case State::DefaultSampleDuration:
-        if (putChar(ch) == 4) {
-            m_defaultSampleDuration = getAs<std::uint32_t>();
+        if (m_parser.putChar(ch) == 4) {
+            m_defaultSampleDuration = m_parser.getAs<std::uint32_t>();
             if (m_tfFlags & TfFlag_DefaultSampleSize) {
                 m_state = State::DefaultSampleSize;
             } else if (m_tfFlags & TfFlag_DefaultSampleFlags) {
@@ -74,24 +74,25 @@ void TrackFragmentHeaderBoxParser::parseChar(std::uint8_t ch)
             } else {
                 m_state = State::Done;
             }
-            m_pos = 0;
+            m_parser.reset();
         }
         break;
     case State::DefaultSampleSize:
-        if (putChar(ch) == 4) {
-            m_defaultSampleSize = getAs<std::uint32_t>();
+        if (m_parser.putChar(ch) == 4) {
+            m_defaultSampleSize = m_parser.getAs<std::uint32_t>();
             if (m_tfFlags & TfFlag_DefaultSampleFlags) {
                 m_state = State::DefaultSampleFlags;
             } else {
                 m_state = State::Done;
             }
-            m_pos = 0;
+            m_parser.reset();
         }
         break;
     case State::DefaultSampleFlags:
-        if (putChar(ch) == 4) {
-            m_defaultSampleFlags = getAs<std::uint32_t>();
+        if (m_parser.putChar(ch) == 4) {
+            m_defaultSampleFlags = m_parser.getAs<std::uint32_t>();
             m_state = State::Done;
+            m_parser.reset();
         }
         break;
     case State::Done:

--- a/src/isobmf/TrackFragmentHeaderBoxParser.h
+++ b/src/isobmf/TrackFragmentHeaderBoxParser.h
@@ -2,6 +2,7 @@
 #pragma once
 
 #include "FullBoxParser.h"
+#include "BinaryParser.h"
 
 #include <optional>
 
@@ -57,6 +58,7 @@ private:
         TfFlag_DefaultSampleFlags       = (1 << 5),
     };
 
+    BinaryParser<8> m_parser;
     State m_state = State::TfFlags;
     std::uint32_t m_tfFlags = 0;
     std::uint32_t m_trackId = 0;

--- a/src/isobmf/UserExtensionBoxParser.cpp
+++ b/src/isobmf/UserExtensionBoxParser.cpp
@@ -10,11 +10,11 @@ void UserExtensionBoxParser::parseChar(std::uint8_t ch)
 {
     switch (m_state) {
     case State::UUID:
-        if (putChar(ch) == 16) {
-            std::copy(m_buf.begin(), m_buf.end(), m_uuid.begin());
-            // TODO: Create a extended user box parser for known UUIDs
+        if (m_parser.putChar(ch) == 16) {
+            std::copy(m_parser.begin(), m_parser.end(), m_uuid.begin());
+            // TODO: Create an extended user data parser for known UUIDs
             m_state = State::Data;
-            m_pos = 0;
+            m_parser.reset();
         }
         break;
     case State::Data:

--- a/src/isobmf/UserExtensionBoxParser.h
+++ b/src/isobmf/UserExtensionBoxParser.h
@@ -2,6 +2,7 @@
 #pragma once
 
 #include "FullBoxParser.h"
+#include "BinaryParser.h"
 
 namespace isobmf {
 
@@ -21,6 +22,7 @@ private:
         Data,
     };
 
+    BinaryParser<16> m_parser;
     State m_state = State::UUID;
     std::array<std::uint8_t, 16> m_uuid;
     std::size_t m_dataSize = 0;


### PR DESCRIPTION
Subj. Different types of boxes may expect different size requirements for parser max length. Also it's easier to test parser when it's implemented as a dedicated class.