### PR TITLE
* Add skeleton for simple XML detector and parser for mdat boxes

### DIFF
--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -59,6 +59,7 @@ bool Application::run()
     DownloaderFactory downloaderFactory;
     auto streamDownloader = downloaderFactory.createDownloader(m_url);
 
+    // TODO: Detect which parser factory to use from file type (MP4, 3GP etc)
     isobmf::BaseParserFactory parserFactory;
     StreamParser streamParser(parserFactory);
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -40,12 +40,17 @@ set(SOURCE_FILES
     isobmf/TrackFragmentRunBoxParser.cpp
     isobmf/UserExtensionBoxParser.h
     isobmf/UserExtensionBoxParser.cpp
+    isobmf/FileFormatDetector.h
+    isobmf/XmlDocumentParser.h
+    isobmf/XmlDocumentParser.cpp
 )
 
 find_library(CURL curl)
+find_library(EXPAT expat)
 
 set(LIBRARY_FILES
     ${CURL}
+    ${EXPAT}
 )
 
 add_executable(${APP_NAME} ${SOURCE_FILES})

--- a/src/isobmf/FileFormatDetector.h
+++ b/src/isobmf/FileFormatDetector.h
@@ -1,0 +1,43 @@
+
+#pragma once
+
+#include <cstddef>
+#include <array>
+#include <regex>
+
+namespace isobmf {
+
+enum class FileFormat
+{
+    InProgress, ///< Detection is incompleted
+    Unknown,    ///< Failed to detect file format
+    XML,        ///< XML detected
+};
+
+/**
+ * File format detector. It attempts to guess file format from first N file characters.
+ * It's very simple. Actually it's soo simple that all what it does is detects an XML document preamble.
+ */
+template <std::size_t MaxSize>
+class FileFormatDetector
+{
+public:
+    FileFormat putChar(char ch)
+    {
+        m_buf[m_pos++] = ch;
+        if (ch == '>') { // End of XML preamble
+            const std::regex regXml("^<\\?xml.+\\?>$");
+            if (std::regex_match(m_buf.begin(), m_buf.begin() + m_pos, regXml)) {
+                return FileFormat::XML;
+            }
+        }
+        return m_pos < m_buf.size() ? FileFormat::InProgress : FileFormat::Unknown;
+    }
+
+private:
+    std::array<char, MaxSize> m_buf;
+    std::size_t m_pos = 0;
+};
+
+
+} // namespace

--- a/src/isobmf/IsoBmfInterfaces.h
+++ b/src/isobmf/IsoBmfInterfaces.h
@@ -3,6 +3,7 @@
 
 #include "IsoBmfTypes.h"
 
+#include <ostream>
 #include <memory>
 
 namespace isobmf {
@@ -55,6 +56,20 @@ public:
             BoxType boxType,
             BoxSize boxSize,
             const BoxParser* parentBox) const = 0;
+};
+
+/**
+ * @brief Interface to parse documents
+ */
+class DocumentParser
+{
+public:
+    virtual ~DocumentParser() = default;
+
+    virtual void startParse() = 0;
+    virtual bool parseChar(std::uint8_t ch) = 0;
+    virtual void endParse() = 0;
+    virtual std::ostream& printDetails(std::ostream& os) const = 0;
 };
 
 } // namespace

--- a/src/isobmf/MovieDataBoxParser.cpp
+++ b/src/isobmf/MovieDataBoxParser.cpp
@@ -1,6 +1,60 @@
 
 #include "MovieDataBoxParser.h"
+#include "XmlDocumentParser.h"
 
 namespace isobmf {
+
+void MovieDataBoxParser::parseChar(std::uint8_t ch)
+{
+    switch (m_state) {
+    case State::DetectFormat:
+        // Keep track of received chars to pass it later into file handler
+        m_buffer += ch;
+        // Feed char into format detector and see what happens
+        switch (m_formatDetector.putChar(ch)) {
+        case FileFormat::InProgress:
+            break;
+        case FileFormat::Unknown:
+            m_state = State::Done;
+            break;
+        case FileFormat::XML:
+            m_documentParser = std::make_unique<XmlDocumentParser>();
+            m_documentParser->startParse();
+            for (const auto ch : m_buffer) {
+                m_documentParser->parseChar(ch);
+            }
+            m_state = State::ParseDocument;
+            break;
+        }
+        break;
+    case State::ParseDocument:
+        if (m_documentParser) {
+            if (!m_documentParser->parseChar(ch)) {
+                m_state = State::Done;
+            }
+        }
+        break;
+    case State::Done:
+        break;
+    }
+}
+
+void MovieDataBoxParser::endParse()
+{
+    // Notify document parser we've finished
+    if (m_documentParser) {
+        m_documentParser->endParse();
+    }
+    Parent::endParse();
+}
+
+std::ostream& MovieDataBoxParser::printDetails(std::ostream& os) const
+{
+    // Print document specific details
+    if (m_documentParser) {
+        m_documentParser->printDetails(os);
+    }
+    return os;
+}
 
 } // namespace

--- a/src/isobmf/MovieDataBoxParser.h
+++ b/src/isobmf/MovieDataBoxParser.h
@@ -2,6 +2,10 @@
 #pragma once
 
 #include "FullBoxParser.h"
+#include "FileFormatDetector.h"
+
+#include <memory>
+#include <string>
 
 namespace isobmf {
 
@@ -21,10 +25,27 @@ aligned(8) class MediaDataBox extends Box(‘mdat’) {
 class MovieDataBoxParser final : public FullBoxParser
 {
 public:
+    using Parent = FullBoxParser;
+
     MovieDataBoxParser(BoxSize boxSize, const BoxParser* parentBox)
         : FullBoxParser("Movie Data", boxSize, parentBox) {}
 
+    void parseChar(std::uint8_t ch) override;
+    void endParse() override;
+    std::ostream& printDetails(std::ostream& os) const override;
+
 private:
+    enum class State
+    {
+        DetectFormat,
+        ParseDocument,
+        Done,
+    };
+
+    State m_state = State::DetectFormat;
+    FileFormatDetector<64> m_formatDetector;
+    std::string m_buffer;
+    std::unique_ptr<DocumentParser> m_documentParser;
 };
 
 } // namespace

--- a/src/isobmf/XmlDocumentParser.cpp
+++ b/src/isobmf/XmlDocumentParser.cpp
@@ -1,0 +1,71 @@
+
+#include "XmlDocumentParser.h"
+
+#include <iostream>
+#include <stdexcept>
+
+namespace isobmf {
+
+XmlDocumentParser::~XmlDocumentParser()
+{
+    if (m_xmlParser) {
+        XML_ParserFree(m_xmlParser);
+    }
+}
+
+void XmlDocumentParser::startParse()
+{
+    m_xmlParser = XML_ParserCreate(nullptr);
+    if (!m_xmlParser) {
+        throw std::runtime_error("Failed to create XML parser");
+    }
+
+    XML_SetUserData(m_xmlParser, this);
+    XML_SetElementHandler(m_xmlParser, startElementHandler, endElementHandler);
+    XML_SetCharacterDataHandler(m_xmlParser, characterDataHandler);
+}
+
+bool XmlDocumentParser::parseChar(std::uint8_t ch)
+{
+    if (m_xmlParser) {
+        char s[2];
+        s[0] = ch;
+        if (XML_Parse(m_xmlParser, s, 1, 0) == XML_STATUS_OK) {
+            return true;
+        }
+    }
+    return false;
+}
+
+void XmlDocumentParser::endParse()
+{
+    if (m_xmlParser) {
+        // Notify parser about last char
+        XML_Parse(m_xmlParser, nullptr, 0, 1);
+    }
+}
+
+std::ostream& XmlDocumentParser::printDetails(std::ostream& os) const
+{
+    // XXX Print details
+    return os;
+}
+
+void XmlDocumentParser::handleElementStart(const XML_Char* name, const XML_Char** atts)
+{
+    std::cout << "start '" << name << "'" << std::endl;
+    // XXX Handle element
+}
+
+void XmlDocumentParser::handleElementEnd(const XML_Char* name)
+{
+    std::cout << "end '" << name << "'" << std::endl;
+    // XXX Handle element
+}
+
+void XmlDocumentParser::handleCharacterData(const XML_Char* s, int len)
+{
+    // XXX Handle data
+}
+
+} // namespace

--- a/src/isobmf/XmlDocumentParser.h
+++ b/src/isobmf/XmlDocumentParser.h
@@ -1,0 +1,46 @@
+
+#pragma once
+
+#include "IsoBmfInterfaces.h"
+
+#include <expat.h>
+
+namespace isobmf {
+
+/**
+ * @brief Parse XML document stream
+ */
+class XmlDocumentParser final : public DocumentParser
+{
+public:
+    ~XmlDocumentParser() override;
+
+    void startParse() override;
+    bool parseChar(std::uint8_t ch) override;
+    void endParse() override;
+    std::ostream& printDetails(std::ostream& os) const override;
+
+private:
+    void handleElementStart(const XML_Char* name, const XML_Char** atts);
+    void handleElementEnd(const XML_Char* name);
+    void handleCharacterData(const XML_Char* s, int len);
+
+    static void startElementHandler(void* userData, const XML_Char* name, const XML_Char** atts)
+    {
+        static_cast<XmlDocumentParser*>(userData)->handleElementStart(name, atts);
+    }
+
+    static void endElementHandler(void* userData, const XML_Char* name)
+    {
+        static_cast<XmlDocumentParser*>(userData)->handleElementEnd(name);
+    }
+
+    static void characterDataHandler(void* userData, const XML_Char* s, int len)
+    {
+        static_cast<XmlDocumentParser*>(userData)->handleCharacterData(s, len);
+    }
+
+    XML_Parser m_xmlParser = nullptr;
+};
+
+} // namespace


### PR DESCRIPTION
Sometimes mdat boxes hold XML documents. For example this can me an Timed Text Markup Language (TTML) documents or whatever. For this cases try to detect XML inside binary "mdat" box and parse it. This is an incomplete basic skeleton based on expat SAX XML parser.