### PR TITLE
Ref box parsers

### DIFF
--- a/src/isobmf/ContainerBoxParser.cpp
+++ b/src/isobmf/ContainerBoxParser.cpp
@@ -9,10 +9,13 @@ namespace isobmf {
 void ContainerBoxParser::startParse()
 {
     printIndent(std::cout) << "Box type: '" << getName() << "' size: " << std::dec << getSize() << " {" << std::endl;
+
+    switchState(State::CompactSize);
 }
 
 void ContainerBoxParser::endParse()
 {
+    // Notify child parser we've finished
     if (m_childBoxParser) {
         m_childBoxParser->endParse();
         m_childBoxParser.reset();
@@ -25,60 +28,57 @@ void ContainerBoxParser::parseChar(std::uint8_t ch)
 {
     switch (m_state) {
     case State::CompactSize:
-        if (m_parser.putChar(ch) == 4) {
-            m_childBoxSize = m_parser.getAs<std::uint32_t>();
+        if (m_parser.putChar(ch) == sizeof(CompactSize)) {
+            m_childBoxSize = m_parser.getAs<CompactSize>();
             if (m_childBoxSize == 1) { // Large size is following
-                m_state = State::ExtendedSize;
+                switchState(State::ExtendedSize);
             } else if (m_childBoxSize == 0) {
-                m_state = State::Type;
+                switchState(State::BoxType);
                 m_dataLeft = 0; // Data spans till the end of file
-            } else if (m_childBoxSize >= 8) {
-                m_state = State::Type;
-                m_dataLeft = m_childBoxSize - 8;
+            } else if (m_childBoxSize >= sizeof(CompactSize) + sizeof(BoxType)) {
+                switchState(State::BoxType);
+                m_dataLeft = m_childBoxSize - sizeof(CompactSize) - sizeof(BoxType);
             } else {
                 std::ostringstream os;
                 os << "Failed to parse box (Invalid box size " << m_childBoxSize << ")";
                 throw std::runtime_error(os.str());
             }
-            m_parser.reset();
         }
         break;
     case State::ExtendedSize:
-        if (m_parser.putChar(ch) == 8) {
-            m_childBoxSize = m_parser.getAs<std::uint64_t>();
+        if (m_parser.putChar(ch) == sizeof(ExtendedSize)) {
+            m_childBoxSize = m_parser.getAs<ExtendedSize>();
             if (m_childBoxSize == 0) {
-                m_state = State::Type;
+                switchState(State::BoxType);
                 m_dataLeft = 0; // Data spans till the end of file
-            } else if (m_childBoxSize >= 16) {
-                m_state = State::Type;
-                m_dataLeft = m_childBoxSize - 16;
+            } else if (m_childBoxSize >= sizeof(CompactSize) + sizeof(ExtendedSize) + sizeof(BoxType)) {
+                switchState(State::BoxType);
+                m_dataLeft = m_childBoxSize - sizeof(CompactSize) - sizeof(ExtendedSize) - sizeof(BoxType);
             } else {
                 std::ostringstream os;
                 os << "Failed to parse box (Invalid box size " << m_childBoxSize << ")";
                 throw std::runtime_error(os.str());
             }
-            m_parser.reset();
         }
         break;
-    case State::Type:
-        if (m_parser.putChar(ch) == 4) {
-            const auto boxType = m_parser.getAs<std::uint32_t>();
+    case State::BoxType:
+        if (m_parser.putChar(ch) == sizeof(BoxType)) {
+            const auto boxType = m_parser.getAs<BoxType>();
             m_childBoxParser = m_boxFactory.createParser(boxType, m_childBoxSize, this);
             if (!m_childBoxParser) {
                 m_childBoxParser = m_boxFactory.createUnknownParser(boxType, m_childBoxSize, this);
             }
             m_childBoxParser->startParse();
             if (!m_childBoxSize || m_dataLeft) {
-                m_state = State::Data;
+                switchState(State::BoxData);
             } else { // No data for this child box
                 m_childBoxParser->endParse();
                 m_childBoxParser.reset();
-                m_state = State::CompactSize;
+                switchState(State::CompactSize);
             }
-            m_parser.reset();
         }
         break;
-    case State::Data:
+    case State::BoxData:
         // Container should pass all data to its children boxes
         if (m_childBoxParser) {
             m_childBoxParser->parseChar(ch);
@@ -86,8 +86,7 @@ void ContainerBoxParser::parseChar(std::uint8_t ch)
         if (m_childBoxSize && --m_dataLeft == 0) { // No more data for this child box
             m_childBoxParser->endParse();
             m_childBoxParser.reset();
-            m_state = State::CompactSize;
-            m_parser.reset();
+            switchState(State::CompactSize);
         }
         break;
     }

--- a/src/isobmf/ContainerBoxParser.h
+++ b/src/isobmf/ContainerBoxParser.h
@@ -45,18 +45,27 @@ public:
     void endParse() override;
 
 private:
+    using CompactSize  = std::uint32_t;
+    using ExtendedSize = std::uint64_t;
+
     enum class State
     {
         CompactSize,    ///< Box compact size (normal)
         ExtendedSize,   ///< Box extended size (optional)
-        Type,           ///< Box type
-        Data,           ///< Box body
+        BoxType,        ///< Box type
+        BoxData,        ///< Box body
     };
+
+    void switchState(State newState) noexcept
+    {
+        m_state = newState;
+        m_parser.reset();
+    }
 
     const ParserFactory& m_boxFactory;
 
     utils::BinaryParser<8> m_parser;
-    State m_state = State::CompactSize;
+    State m_state;
     BoxSize m_childBoxSize;
     std::unique_ptr<BoxParser> m_childBoxParser;
     BoxSize m_dataLeft;

--- a/src/isobmf/FileFormatDetector.h
+++ b/src/isobmf/FileFormatDetector.h
@@ -34,6 +34,11 @@ public:
         return m_pos < m_buf.size() ? FileFormat::InProgress : FileFormat::Unknown;
     }
 
+    void reset() noexcept
+    {
+        m_pos = 0;
+    }
+
 private:
     std::array<char, MaxSize> m_buf;
     std::size_t m_pos = 0;

--- a/src/isobmf/FileTypeBoxParser.cpp
+++ b/src/isobmf/FileTypeBoxParser.cpp
@@ -4,28 +4,31 @@
 
 namespace isobmf {
 
+void FileTypeBoxParser::startParse()
+{
+    switchState(State::MajorBrand);
+}
+
 void FileTypeBoxParser::parseChar(std::uint8_t ch)
 {
     switch (m_state) {
     case State::MajorBrand:
-        if (m_parser.putChar(ch) == 4) {
-            m_majorBrand = m_parser.getAs<std::uint32_t>();
-            m_state = State::MinorVersion;
-            m_parser.reset();
+        if (m_parser.putChar(ch) == sizeof(BrandNumber)) {
+            m_majorBrand = m_parser.getAs<BrandNumber>();
+            switchState(State::MinorVersion);
         }
         break;
     case State::MinorVersion:
-        if (m_parser.putChar(ch) == 4) {
-            m_minorVersion = m_parser.getAs<std::uint32_t>();
-            m_state = State::CompatibleBrands;
-            m_parser.reset();
+        if (m_parser.putChar(ch) == sizeof(VersionNumber)) {
+            m_minorVersion = m_parser.getAs<VersionNumber>();
+            switchState(State::CompatibleBrands);
         }
         break;
     case State::CompatibleBrands:
-        if (m_parser.putChar(ch) == 4) {
-            const auto brandCode = m_parser.getAs<std::uint32_t>();
+        if (m_parser.putChar(ch) == sizeof(BrandNumber)) {
+            const auto brandCode = m_parser.getAs<BrandNumber>();
             m_compatibleBrands.push_back(brandCode);
-            m_parser.reset();
+            switchState(State::CompatibleBrands);
         }
         break;
     }
@@ -35,6 +38,7 @@ std::ostream& FileTypeBoxParser::printDetails(std::ostream& os) const
 {
     os << "majorBrand: " << makeBrandName(m_majorBrand) << " ";
     os << "minorVersion: "  << std::dec << m_minorVersion << " ";
+
     auto numBrands = m_compatibleBrands.size();
     os << "compatibleBrands: {";
     for (const auto brandName : m_compatibleBrands) {
@@ -42,6 +46,7 @@ std::ostream& FileTypeBoxParser::printDetails(std::ostream& os) const
           if (--numBrands) os << " ";
     }
     os << "}";
+
     return os;
 }
 

--- a/src/isobmf/FileTypeBoxParser.h
+++ b/src/isobmf/FileTypeBoxParser.h
@@ -30,10 +30,14 @@ public:
     FileTypeBoxParser(BoxSize boxSize, const BoxParser* parentBox)
         : FullBoxParser("File Type", boxSize, parentBox) {}
 
+    void startParse() override;
     void parseChar(std::uint8_t ch) override;
     std::ostream& printDetails(std::ostream& os) const override;
 
 private:
+    using BrandNumber   = std::uint32_t;
+    using VersionNumber = std::uint32_t;
+
     enum class State
     {
         MajorBrand,
@@ -41,11 +45,17 @@ private:
         CompatibleBrands,
     };
 
+    void switchState(State newState) noexcept
+    {
+        m_state = newState;
+        m_parser.reset();
+    }
+
     utils::BinaryParser<4> m_parser;
-    State m_state = State::MajorBrand;
-    std::uint32_t m_majorBrand = 0;
-    std::uint32_t m_minorVersion = 0;
-    std::vector<std::uint32_t> m_compatibleBrands;
+    State m_state;
+    BrandNumber m_majorBrand = 0;
+    VersionNumber m_minorVersion = 0;
+    std::vector<BrandNumber> m_compatibleBrands;
 };
 
 } // namespace

--- a/src/isobmf/MovieDataBoxParser.cpp
+++ b/src/isobmf/MovieDataBoxParser.cpp
@@ -4,6 +4,12 @@
 
 namespace isobmf {
 
+void MovieDataBoxParser::startParse()
+{
+    m_state = State::DetectFormat;
+    m_formatDetector.reset();
+}
+
 void MovieDataBoxParser::parseChar(std::uint8_t ch)
 {
     switch (m_state) {

--- a/src/isobmf/MovieDataBoxParser.h
+++ b/src/isobmf/MovieDataBoxParser.h
@@ -30,6 +30,7 @@ public:
     MovieDataBoxParser(BoxSize boxSize, const BoxParser* parentBox)
         : FullBoxParser("Movie Data", boxSize, parentBox) {}
 
+    void startParse() override;
     void parseChar(std::uint8_t ch) override;
     void endParse() override;
     std::ostream& printDetails(std::ostream& os) const override;

--- a/src/isobmf/MovieFragmentHeaderBoxParser.h
+++ b/src/isobmf/MovieFragmentHeaderBoxParser.h
@@ -25,20 +25,30 @@ public:
     MovieFragmentHeaderBoxParser(BoxSize boxSize, const BoxParser* parentBox)
         : FullBoxParser("Movie Fragment Header", boxSize, parentBox) {}
 
+    void startParse() override;
     void parseChar(std::uint8_t ch) override;
     std::ostream& printDetails(std::ostream& os) const override;
 
 private:
+    using ReservedField  = std::uint32_t;
+    using SequenceNumber = std::uint32_t;
+
     enum class State
     {
-        Reserved,
+        ReservedField,
         SequenceNumber,
         Done,
     };
 
+    void switchState(State newState) noexcept
+    {
+        m_state = newState;
+        m_parser.reset();
+    }
+
     utils::BinaryParser<4> m_parser;
-    State m_state = State::Reserved;
-    std::uint32_t m_sequenceNumber = 0;
+    State m_state = State::ReservedField;
+    SequenceNumber m_sequenceNumber = 0;
 };
 
 } // namespace

--- a/src/isobmf/TrackFragmentHeaderBoxParser.h
+++ b/src/isobmf/TrackFragmentHeaderBoxParser.h
@@ -33,6 +33,7 @@ public:
     TrackFragmentHeaderBoxParser(BoxSize boxSize, const BoxParser* parentBox)
         : FullBoxParser("Track Fragment Header", boxSize, parentBox) {}
 
+    void startParse() override;
     void parseChar(std::uint8_t ch) override;
     std::ostream& printDetails(std::ostream& os) const override;
 
@@ -49,7 +50,21 @@ private:
         Done,
     };
 
-    enum : std::uint32_t
+    void switchState(State newState) noexcept
+    {
+        m_state = newState;
+        m_parser.reset();
+    }
+
+    using TfFlags                   = std::uint32_t;
+    using TrackId                   = std::uint32_t;
+    using BaseDataOffset            = std::uint64_t;
+    using SampleDescriptionIndex    = std::uint32_t;
+    using DefaultSampleDuration     = std::uint32_t;
+    using DefaultSampleSize         = std::uint32_t;
+    using DefaultSampleFlags        = std::uint32_t;
+
+    enum : TfFlags
     {
         TfFlag_BaseDataOffset           = (1 << 0),
         TfFlag_SampleDescriptionIndex   = (1 << 1),
@@ -59,14 +74,14 @@ private:
     };
 
     utils::BinaryParser<8> m_parser;
-    State m_state = State::TfFlags;
-    std::uint32_t m_tfFlags = 0;
-    std::uint32_t m_trackId = 0;
-    std::optional<std::uint64_t> m_baseDataOffset;
-    std::optional<std::uint32_t> m_sampleDescriptionIndex;
-    std::optional<std::uint32_t> m_defaultSampleDuration;
-    std::optional<std::uint32_t> m_defaultSampleSize;
-    std::optional<std::uint32_t> m_defaultSampleFlags;
+    State m_state;
+    TfFlags                                 m_tfFlags;
+    TrackId                                 m_trackId;
+    std::optional<BaseDataOffset>           m_baseDataOffset;
+    std::optional<SampleDescriptionIndex>   m_sampleDescriptionIndex;
+    std::optional<DefaultSampleDuration>    m_defaultSampleDuration;
+    std::optional<DefaultSampleSize>        m_defaultSampleSize;
+    std::optional<DefaultSampleFlags>       m_defaultSampleFlags;
 };
 
 } // namespace

--- a/src/isobmf/TrackFragmentRunBoxParser.cpp
+++ b/src/isobmf/TrackFragmentRunBoxParser.cpp
@@ -5,8 +5,7 @@ namespace isobmf {
 
 void TrackFragmentRunBoxParser::startParse()
 {
-    m_state = State::TrFlags;
-    m_parser.reset();
+    switchState(State::TrFlags);
 }
 
 void TrackFragmentRunBoxParser::parseChar(std::uint8_t ch)
@@ -15,42 +14,38 @@ void TrackFragmentRunBoxParser::parseChar(std::uint8_t ch)
     case State::TrFlags:
         if (m_parser.putChar(ch) == sizeof(TrFlags)) {
             m_trFlags = m_parser.getAs<TrFlags>();
-            m_state = State::SampleCount;
-            m_parser.reset();
+            switchState(State::SampleCount);
         }
         break;
     case State::SampleCount:
         if (m_parser.putChar(ch) == sizeof(SampleCount)) {
             m_sampleCount = m_parser.getAs<SampleCount>();
             if (m_trFlags & TrFlag_DataOffset) {
-                m_state = State::DataOffset;
+                switchState(State::DataOffset);
             } else if (m_trFlags & TrFlag_FirstSampleFlags) {
-                m_state = State::FirstSampleFlags;
+                switchState(State::FirstSampleFlags);
             } else {
                 // TODO: Parse array of samples
-                m_state = State::Done;
+                switchState(State::Done);
             }
-            m_parser.reset();
         }
         break;
     case State::DataOffset:
         if (m_parser.putChar(ch) == sizeof(DataOffset)) {
             m_dataOffset = m_parser.getAs<DataOffset>();
             if (m_trFlags & TrFlag_FirstSampleFlags) {
-                m_state = State::FirstSampleFlags;
+                switchState(State::FirstSampleFlags);
             } else {
                 // TODO: Parse array of samples
-                m_state = State::Done;
+                switchState(State::Done);
             }
-            m_parser.reset();
         }
         break;
     case State::FirstSampleFlags:
         if (m_parser.putChar(ch) == sizeof(FirstSampleFlags)) {
             m_firstSampleFlags = m_parser.getAs<FirstSampleFlags>();
             // TODO: Parse array of samples
-            m_state = State::Done;
-            m_parser.reset();
+            switchState(State::Done);
         }
         break;
     case State::Done:

--- a/src/isobmf/TrackFragmentRunBoxParser.h
+++ b/src/isobmf/TrackFragmentRunBoxParser.h
@@ -66,7 +66,7 @@ private:
         TrFlag_FirstSampleFlags = (1 << 2),
     };
 
-    State                       m_state = State::TrFlags;
+    State                       m_state;
     utils::BinaryParser<4>      m_parser;
     TrFlags                     m_trFlags;
     SampleCount                 m_sampleCount;

--- a/src/isobmf/TrackFragmentRunBoxParser.h
+++ b/src/isobmf/TrackFragmentRunBoxParser.h
@@ -55,6 +55,12 @@ private:
         Done,
     };
 
+    void switchState(State newState) noexcept
+    {
+        m_state = newState;
+        m_parser.reset();
+    }
+
     using TrFlags          = std::uint32_t;
     using SampleCount      = std::uint32_t;
     using DataOffset       = std::int32_t;

--- a/src/isobmf/UserExtensionBoxParser.cpp
+++ b/src/isobmf/UserExtensionBoxParser.cpp
@@ -6,6 +6,12 @@
 
 namespace isobmf {
 
+void UserExtensionBoxParser::startParse()
+{
+    switchState(State::UUID);
+    m_dataSize = 0;
+}
+
 void UserExtensionBoxParser::parseChar(std::uint8_t ch)
 {
     switch (m_state) {
@@ -13,8 +19,7 @@ void UserExtensionBoxParser::parseChar(std::uint8_t ch)
         if (m_parser.putChar(ch) == 16) {
             std::copy(m_parser.begin(), m_parser.end(), m_uuid.begin());
             // TODO: Create an extended user data parser for known UUIDs
-            m_state = State::Data;
-            m_parser.reset();
+            switchState(State::Data);
         }
         break;
     case State::Data:

--- a/src/isobmf/UserExtensionBoxParser.h
+++ b/src/isobmf/UserExtensionBoxParser.h
@@ -12,6 +12,7 @@ public:
     UserExtensionBoxParser(BoxSize boxSize, const BoxParser* parentBox)
         : FullBoxParser("User Extension", boxSize, parentBox) {}
 
+    void startParse() override;
     void parseChar(std::uint8_t ch) override;
     std::ostream& printDetails(std::ostream& os) const override;
 
@@ -22,10 +23,16 @@ private:
         Data,
     };
 
+    void switchState(State newState) noexcept
+    {
+        m_state = newState;
+        m_parser.reset();
+    }
+
     utils::BinaryParser<16> m_parser;
-    State m_state = State::UUID;
-    std::array<std::uint8_t, 16> m_uuid;
-    std::size_t m_dataSize = 0;
+    State m_state;
+    std::array<std::uint8_t, 16> m_uuid; // TODO: Add class to handle UUIDs
+    std::size_t m_dataSize;
 };
 
 } // namespace


### PR DESCRIPTION
Refactor box parsers:
* Reset parser state inside startParse() method to make it reenterable
* Switch parser state through switchState() method that also enforces parser reset
* Prefer named data types over hardcoded
* 